### PR TITLE
Update SearXNG to cd75013c9

### DIFF
--- a/.github/.synced_commit
+++ b/.github/.synced_commit
@@ -1,1 +1,1 @@
-cba0cffa8
+cd75013c9

--- a/searxng/requirements.txt
+++ b/searxng/requirements.txt
@@ -13,7 +13,7 @@ sniffio==1.3.1
 valkey==6.1.1
 markdown-it-py==4.0.0
 msgspec==0.21.1
-typer==0.25.0
+typer==0.25.1
 isodate==0.7.2
 whitenoise==6.12.0
 typing-extensions==4.15.0


### PR DESCRIPTION
Update SearXNG to cd75013c9

## New commits:
- [upd] pypi: Bump typer from 0.25.0 to 0.25.1 in the minor group (#6040) (cd75013c9)